### PR TITLE
Add support for setting the PDF author via the properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,13 @@
       <dependency>
          <groupId>org.apache.pdfbox</groupId>
          <artifactId>pdfbox</artifactId>
-         <version>2.0.1</version>
+         <version>2.0.2</version>
       </dependency>
 
       <dependency>
          <groupId>org.apache.pdfbox</groupId>
          <artifactId>xmpbox</artifactId>
-         <version>2.0.1</version>
+         <version>2.0.2</version>
       </dependency>
 
       <!-- Optional DI -->

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
    <modelVersion>4.0.0</modelVersion>
 
    <artifactId>pdfbox-carriage</artifactId>
-   <version>1.0.1-SNAPSHOT</version>
+   <version>1.0.1</version>
 
    <parent>
       <groupId>io.konik</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
    <modelVersion>4.0.0</modelVersion>
 
    <artifactId>pdfbox-carriage</artifactId>
-   <version>1.0.0</version>
+   <version>1.0.1-SNAPSHOT</version>
 
    <parent>
       <groupId>io.konik</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
    <modelVersion>4.0.0</modelVersion>
 
    <artifactId>pdfbox-carriage</artifactId>
-   <version>1.0.1-SNAPSHOT</version>
+   <version>1.0.0</version>
 
    <parent>
       <groupId>io.konik</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
    <modelVersion>4.0.0</modelVersion>
 
    <artifactId>pdfbox-carriage</artifactId>
-   <version>1.0.1</version>
+   <version>1.0.2-SNAPSHOT</version>
 
    <parent>
       <groupId>io.konik</groupId>

--- a/src/main/java/io/konik/Configuration.java
+++ b/src/main/java/io/konik/Configuration.java
@@ -1,0 +1,114 @@
+/* Copyright (C) 2014 konik.io
+ *
+ * This file is part of the Konik library.
+ *
+ * The Konik library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * The Konik library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with the Konik library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.konik;
+
+import static java.util.logging.Level.CONFIG;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * The Global Konik Configuration.
+ * 
+ * Try to load Konik Configuration from file
+ * `io.konik.configuration.properties`. System properties provided with the
+ * +-Dio.konik*+ or ```System.setProperties("io.konik*")`` will override the
+ * file content.
+ * 
+ */
+public enum Configuration {
+
+	/** The singleton configuration instance. */
+	INSTANCE;
+
+	private static final Logger LOG = Logger.getLogger(Configuration.class.getName());
+	private final Properties properties;
+
+	Configuration() {
+		properties = new Properties();
+		loadPropertiesFromFile();
+		overwriteWithSystemProperties();
+	}
+
+	void reload() {
+		loadPropertiesFromFile();
+		overwriteWithSystemProperties();
+	}
+
+	private void loadPropertiesFromFile() {
+		String fileName = Configuration.class.getName().toLowerCase();
+		InputStream propertiesStream = this.getClass().getResourceAsStream("/" + fileName + ".properties");
+		if (propertiesStream != null) {
+			try {
+				properties.load(propertiesStream);
+			} catch (IOException e) {
+				LOG.log(CONFIG, "could not load properties file" + fileName + " from classpath", e);
+			}
+		}
+	}
+
+	private void overwriteWithSystemProperties() {
+		for (Entry<Object, Object> sysProperty : System.getProperties().entrySet()) {
+			if (sysProperty.getKey() instanceof String
+					&& ((String) sysProperty.getKey()).startsWith("io.konik.carriage.pdf")) {
+				properties.put(sysProperty.getKey(), sysProperty.getValue());
+			}
+		}
+	}
+
+	/**
+	 * Searches for the property with the specified key in this property list.
+	 * If the key is not found in this property list, the default property list,
+	 * and its defaults, recursively, are then checked. The method returns
+	 * <code>null</code> if the property is not found.
+	 *
+	 * @param key
+	 *            the property key.
+	 * @return the value in this property list with the specified key value.
+	 * @see Configuration#getProperty(String, String)
+	 */
+	public String getProperty(String key) {
+		return properties.getProperty(key);
+	}
+
+	/**
+	 * Searches for the property with the specified key in this property list.
+	 * If the key is not found in this property list, the default property list,
+	 * and its defaults, recursively, are then checked. The method returns the
+	 * default value argument if the property is not found.
+	 *
+	 * @param key
+	 *            the hashtable key.
+	 * @param defaultValue
+	 *            a default value.
+	 *
+	 * @return the value in this property list with the specified key value.
+	 * @see Configuration#getProperty(String)
+	 */
+	public String getProperty(String key, String defaultValue) {
+		return properties.getProperty(key, defaultValue);
+	}
+
+	@Override
+	public String toString() {
+		return "PDFBox Carriage Configuration dump\n" + properties.toString();
+	}
+}

--- a/src/main/java/io/konik/carriage/pdfbox/PDFBoxInvoiceAppender.java
+++ b/src/main/java/io/konik/carriage/pdfbox/PDFBoxInvoiceAppender.java
@@ -18,6 +18,8 @@
 package io.konik.carriage.pdfbox;
 
 import static java.util.Collections.singletonMap;
+
+import io.konik.Configuration;
 import io.konik.carriage.pdfbox.exception.NotPDFAException;
 import io.konik.carriage.pdfbox.xmp.XMPSchemaZugferd1p0;
 import io.konik.carriage.utils.ByteCountingInputStream;
@@ -69,6 +71,8 @@ public class PDFBoxInvoiceAppender implements FileAppender {
    private static final String PRODUCER = "Konik Library with PDFBox-Carriage";
    private static final String MIME_TYPE = "text/xml";
    private static final String ZF_FILE_NAME = "ZUGFeRD-invoice.xml";
+   private static final String USER_NAME_KEY = "user.name";
+   private static final String PDF_AUTHOR_KEY = "io.konik.carriage.pdf.author";
    private final XMPMetadata zfDefaultXmp;
 
    /**
@@ -227,10 +231,16 @@ public class PDFBoxInvoiceAppender implements FileAppender {
    }
 
    private static String getAuthor() {
-      if (System.getProperty("io.konik.carriage.pdf.author") != null) {
-         return System.getProperty("io.konik.carriage.pdf.author");
+      String defaultAuthor = getDefaultAuthor();
+      return Configuration.INSTANCE.getProperty(PDF_AUTHOR_KEY, defaultAuthor);
+
+   }
+
+   private static String getDefaultAuthor() {
+      if (System.getProperty(PDF_AUTHOR_KEY) != null) {
+         return System.getProperty(PDF_AUTHOR_KEY);
       }
-      return System.getProperty("user.name");
+      return System.getProperty(USER_NAME_KEY);
    }
 
 }


### PR DESCRIPTION
This change introduces a `Configuration` class which allows for setting the PDF author name using the `io.konik.configuration.properties` file that is used for [setting properties in the konik project](http://konik.io/docs/index.html#property_file). When no author name is defined in the properties file, a default name will be used.

Further properties can be supported easily, if needed.

See https://github.com/konik-io/konik/issues/37
